### PR TITLE
Reconnect websocket when window receives focus

### DIFF
--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -93,6 +93,8 @@ export default {
     moment.locale(navigator.language)
     this.connect()
 
+    window.addEventListener(focus, () => this.connect())
+
     //  Start the progress bar on app start
     this.$Progress.start()
 


### PR DESCRIPTION
Hi -- I'm a long time happy user of forked-daapd/owntone and the web interface.

I use the web interface as a home screen shortcut on my iPhone and often find that when I switch away from it for a few minutes, then return to it, the websocket is disconnected and doesn't reconnect automatically.

This PR fixes the above problem by reconnecting to the socket when the web interface gains focus.