### PR TITLE
Fix failure to detect apple-touch-icon.png

### DIFF
--- a/web-src/index.html
+++ b/web-src/index.html
@@ -6,7 +6,7 @@
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/apple-touch-icon.png"
+      href="/apple-touch-icon.png?ver=2.0"
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/web-src/index.html
+++ b/web-src/index.html
@@ -6,7 +6,7 @@
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/apple-touch-icon.png?ver2.0"
+      href="/apple-touch-icon.png"
     />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
When I add Owntone to the home screen on my iPhone (iOS 15), the apple-touch-icon is not recognised. The "?ver2.0" seems to be non-standard, and removing it fixes the problem.