### PR TITLE
Update visible information when window gains focus

### DIFF
--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -118,12 +118,14 @@ export default {
 
   methods: {
     connect: function () {
+      /*
       this.$store.dispatch('add_notification', {
         text: 'Connecting to OwnTone server',
         type: 'info',
         topic: 'connection',
         timeout: 2000
       })
+      */
 
       webapi
         .config()
@@ -179,12 +181,14 @@ export default {
       })
 
       socket.onopen = function () {
+        /*
         vm.$store.dispatch('add_notification', {
           text: 'Connection to server established',
           type: 'primary',
           topic: 'connection',
           timeout: 2000
         })
+        */
         vm.reconnect_attempts = 0
         socket.send(
           JSON.stringify({
@@ -215,6 +219,7 @@ export default {
       socket.onclose = function () {
         // vm.$store.dispatch('add_notification', { text: 'Connection closed', type: 'danger', timeout: 2000 })
       }
+      /*
       socket.onerror = function () {
         vm.reconnect_attempts++
         vm.$store.dispatch('add_notification', {
@@ -224,6 +229,7 @@ export default {
           topic: 'connection'
         })
       }
+      */
 
       // When the app becomes active, force an update of all information, because we
       // may have missed notifications while the app was inactive.

--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -174,7 +174,8 @@ export default {
       }
 
       const socket = new ReconnectingWebSocket(wsUrl, 'notify', {
-        reconnectInterval: 3000
+        reconnectInterval: 1000,
+        maxReconnectInterval: 2000
       })
 
       socket.onopen = function () {


### PR DESCRIPTION
Further to the previous PR #2, I realised that two different events are fired when the window becomes active in different way (change tab vs change app), and this PR responds to both. I also found that it is not necessary to restart the websocket, so long as the reconnectingWebSocket `maxReconnectInterval` is short. All that is needed is to update the visible info ("Now playing" etc) in the interface.

With the two changes above, the reconnect is 100% reliable for me, so I also commented out the notifications, which are now unneeded (and a bit annoying).